### PR TITLE
Fix picker not displaying featured categories

### DIFF
--- a/src/components/body/CategoryList.tsx
+++ b/src/components/body/CategoryList.tsx
@@ -13,10 +13,19 @@ export interface CategoryListProps {
 }
 
 function CategoryList({ categories, trending, columnsCount }: CategoryListProps): JSX.Element {
-	// Reduce categories to multiple of columns so there won't by any not full rows at the bottom
-	let categoriesSliced = categories;
-	if(columnsCount > 1) {
-		categoriesSliced = categories?.slice(0, -((categories.length + 1) % columnsCount));
+	/**
+     * Make sure that last categories row is always full by removing
+     * excess categories so the total count is devisable by collumn count
+     */
+	function getCleanedCategories() {
+		if(!categories) return undefined;
+
+		const SPECIAL_CATEGORIES_COUNT = 1; // Trending
+		const totalCategoriesCount = categories.length + SPECIAL_CATEGORIES_COUNT;
+		const excessCategoriesCount = totalCategoriesCount % columnsCount;
+
+		if(excessCategoriesCount == 0) return categories;
+		return categories?.slice(0, -excessCategoriesCount);
 	}
 
 	return (
@@ -24,7 +33,7 @@ function CategoryList({ categories, trending, columnsCount }: CategoryListProps)
 			{categories && trending ? (
 				<>
 					<TrendingCategory image={trending.url} />
-					{categoriesSliced?.map((cat, i) => (
+					{getCleanedCategories()?.map((cat, i) => (
 						<FeaturedCategory key={i} image={cat.image} name={cat.name} />
 					))}
 				</>


### PR DESCRIPTION
In recent weeks Tenor reduced the number of featured categories from `58` to `57` which revealed a critical flaw in the categories rendering code. 

![image](https://github.com/MrBartusek/gif-picker-react/assets/23432278/1dc3a687-2d26-4090-b1ba-bfd6a48e398d)

Picker has a built-in system that removes a couple of last categories when they can't be divided by column count so there are not any half-filled rows at the end. This system apparently breaks when there are no columns to remove since:

```ts
categories.slice(0, -1); // removes last 1 category
categories.slice(0, -0); // removes all categories, for some reason
```

This PR fixes that:

![image](https://github.com/MrBartusek/gif-picker-react/assets/23432278/9a08bb6d-60ef-4a75-bbb0-8fc060f36977)
