### PR TITLE
Fix Category & Gif buttons subbmiting forms

### DIFF
--- a/src/components/body/Category.tsx
+++ b/src/components/body/Category.tsx
@@ -13,6 +13,7 @@ function Category({ image, text, onClick}: CategoryProps): JSX.Element {
 
 	return (
 		<button
+			type="button"
 			className='gpr-btn gpr-category'
 			style={{height: settings.categoryHeight}}
 			data-testid='gpr-category'

--- a/src/components/body/ResultImage.tsx
+++ b/src/components/body/ResultImage.tsx
@@ -21,6 +21,7 @@ function ResultImage({ image, searchTerm }: ResultImageProps): JSX.Element {
 
 	return (
 		<button
+			type="button"
 			className='gpr-btn gpr-result-image'
 			onClick={onClick}
 		>


### PR DESCRIPTION
Button types has been implemented to prevent form submission when selecting(clicking) a GIF and utilizing the component within a form.