### PR TITLE
feat: allow to set `initialSearchTerm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ The following props are accepted by the picker:
 | contentFilter | `ContentFilter` | `ContentFilter.OFF` | Controls the Tenor [Content filtering](https://developers.google.com/tenor/guides/content-filtering) options. If you are using Typescript you can use `ContentFilter` enum. Possible values are `high`, `medium`, `low`, `off`  |
 | clientKey | `string` | `gif-picker-react` | Name of your application. Used to differentiate multiple applications using same API key. |
 | country | `string` | `US` | Specify the country of origin for the request. To do so, provide its two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code. |
-| locale | `string (xx_YY)` | `en_US` | Specify the default language to interpret the search string. xx is the language's [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code, while the optional _YY value is the two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code.
-| width | `number / string` | `350` | Controls the width of the picker. You can provide a number that will be treated as pixel size, or your any accepted css width as string.
-| height | `number / string` | `450` | Controls the height of the picker. You can provide a number that will be treated as pixel size, or your any accepted css width as string.
-| categoryHeight | `number / string` | `100` | Controls the height of the home page reaction category. You can provide a number that will be treated as pixel size, or your any accepted css width as string.
+| locale | `string (xx_YY)` | `en_US` | Specify the default language to interpret the search string. xx is the language's [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code, while the optional _YY value is the two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code. |
+| width | `number / string` | `350` | Controls the width of the picker. You can provide a number that will be treated as pixel size, or your any accepted css width as string. |
+| height | `number / string` | `450` | Controls the height of the picker. You can provide a number that will be treated as pixel size, or your any accepted css width as string. |
+| categoryHeight | `number / string` | `100` | Controls the height of the home page reaction category. You can provide a number that will be treated as pixel size, or your any accepted css width as string. |
+| initialSearchTerm | `string` | `""` | Allow to set the initial search term to show relevant results when the input is empty, be aware that categories won't show up since the term will always have a fallback value. |
 
 ### TenorImage
 

--- a/src/GifPickerReact.tsx
+++ b/src/GifPickerReact.tsx
@@ -23,15 +23,16 @@ export interface GifPickerReactProps {
 	height?: number | string;
 	categoryHeight?: number | string;
 	theme?: Theme;
+	initialSearchTerm?: string;
 }
 
 function GifPickerReact(props: GifPickerReactProps): JSX.Element {
 	const settings = useSettings(props);
-	const pickerContext = usePickerContext();
+	const pickerContext = usePickerContext({ initialSearchTerm: settings.initialSearchTerm });
 	const tenorManager: TenorManager = useMemo(() => (
 		new TenorManager(settings.tenorApiKey, settings.clientKey,
 			settings.country, settings.locale, settings.contentFilter)
-	), [ ]);
+	), []);
 
 	return (
 		<SettingsContext.Provider value={settings}>

--- a/src/components/body/Body.tsx
+++ b/src/components/body/Body.tsx
@@ -51,10 +51,10 @@ function Body({ width }: BodyProps): JSX.Element {
 	return (
 		<div className='gpr-body' ref={ref}>
 			{((): JSX.Element => {
-				if(pickerContext.showTrending) {
+				if (pickerContext.showTrending) {
 					return <TrendingResult columnsCount={columnsCount} />;
 				}
-				else if(pickerContext.searchTerm) {
+				else if (pickerContext.searchTerm || pickerContext.initialSearchTerm) {
 					return <SearchResult columnsCount={columnsCount} searchTerm={pickerContext.searchTerm} />;
 				}
 				else {

--- a/src/components/body/SearchResult.tsx
+++ b/src/components/body/SearchResult.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import TenorContext from '../../context/TenorContext';
+import PickerContext from '../../context/PickerContext';
 import { TenorResult } from '../../managers/TenorManager';
 import GifList from './GifList';
 
@@ -9,20 +10,21 @@ export interface SearchResultProps {
 }
 
 function SearchResult({ searchTerm, columnsCount }: SearchResultProps) {
-	const [ searchResult, setSearchResult ] = useState<TenorResult>(null!);
-	const [ isLoading, setLoading ] = useState(true);
+	const [searchResult, setSearchResult] = useState<TenorResult>(null!);
+	const [isLoading, setLoading] = useState(true);
+	const [pickerContext] = useContext(PickerContext);
 	const tenor = useContext(TenorContext);
 
 	useEffect(() => {
 		setLoading(true);
 		async function search(): Promise<any> {
-			const result = await tenor.search(searchTerm);
+			const result = await tenor.search(searchTerm || pickerContext.initialSearchTerm);
 			setSearchResult(result);
 			setLoading(false);
 		}
 		const debounce = setTimeout(() => search(), 800);
 		return (): void => clearTimeout(debounce);
-	}, [ searchTerm ]);
+	}, [searchTerm, pickerContext.initialSearchTerm]);
 
 	return (
 		<GifList isLoading={isLoading} columnsCount={columnsCount} result={searchResult} searchTerm={searchTerm} />

--- a/src/hooks/usePickerContext.ts
+++ b/src/hooks/usePickerContext.ts
@@ -1,19 +1,25 @@
 import { Dispatch, SetStateAction, useState } from 'react';
 
 export interface PickerContextType {
-    searchTerm: string;
-	showTrending: boolean
+	searchTerm: string;
+	showTrending: boolean;
+	initialSearchTerm: string;
 }
 
-function usePickerContext(): [PickerContextType, Dispatch<SetStateAction<PickerContextType>>] {
+export type PickerContextSettings = {
+	initialSearchTerm: string;
+}
+
+function usePickerContext(props: PickerContextSettings): [PickerContextType, Dispatch<SetStateAction<PickerContextType>>] {
 	const DEFAULT_SETTINGS: PickerContextType = {
+		initialSearchTerm: props.initialSearchTerm,
 		searchTerm: '',
 		showTrending: false
 	};
 
-	const [ pickerContext, setPickerContext ] = useState<PickerContextType>(DEFAULT_SETTINGS);
+	const [pickerContext, setPickerContext] = useState<PickerContextType>(DEFAULT_SETTINGS);
 
-	return [ pickerContext, setPickerContext ];
+	return [pickerContext, setPickerContext];
 }
 
 export default usePickerContext;

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -16,6 +16,7 @@ export type GifPickerSettings = {
 	width: string;
 	categoryHeight: string;
 	theme: Theme;
+	initialSearchTerm: string;
 }
 
 function useSettings(props: GifPickerReactProps): GifPickerSettings {
@@ -30,10 +31,11 @@ function useSettings(props: GifPickerReactProps): GifPickerSettings {
 		country: props.country ?? 'US',
 		locale: props.locale ?? 'en_US',
 		contentFilter: props.contentFilter ?? ContentFilter.OFF,
-		height: praseDimension(props.height ?? 450),
-		width: praseDimension(props.width ?? 350),
-		categoryHeight: praseDimension(props.categoryHeight ?? 100),
-		theme: getTheme(props.theme)
+		height: parseDimension(props.height ?? 450),
+		width: parseDimension(props.width ?? 350),
+		categoryHeight: parseDimension(props.categoryHeight ?? 100),
+		theme: getTheme(props.theme),
+		initialSearchTerm: props.initialSearchTerm ?? '',
 	};
 }
 
@@ -43,7 +45,7 @@ function useSettings(props: GifPickerReactProps): GifPickerSettings {
  * @param dimension raw dimension
  * @returns css size string
  */
-function praseDimension(dimension: string | number): string {
+function parseDimension(dimension: string | number): string {
 	if(typeof dimension == 'number') {
 		return `${dimension}px`;
 	}

--- a/src/managers/TenorManager.ts
+++ b/src/managers/TenorManager.ts
@@ -25,7 +25,7 @@ class TenorManager {
 		clientKey: string,
 		country: string,
 		locale: string,
-		contentFilter: ContentFilter
+		contentFilter: ContentFilter,
 	) {
 		this.apiKey = apiKey;
 		this.clientKey = clientKey;
@@ -60,7 +60,7 @@ class TenorManager {
 			});
 	}
 
-	private praseResult(img: any): TenorImage {
+	private parseResult(img: any): TenorImage {
 		const preview = img['media_formats']['tinygif'];
 		const gif = img['media_formats']['gif'];
 
@@ -103,7 +103,7 @@ class TenorManager {
 		})
 			.then((data: any) => {
 				const results = data.results;
-				const images = results.map(this.praseResult);
+				const images = results.map(this.parseResult);
 				return {
 					next: data.next,
 					images: images
@@ -118,7 +118,7 @@ class TenorManager {
 		})
 			.then((data: any) => {
 				const results = data.results;
-				const images = results.map(this.praseResult);
+				const images = results.map(this.parseResult);
 				return {
 					next: data.next,
 					images: images

--- a/src/stories/GifPicker.stories.tsx
+++ b/src/stories/GifPicker.stories.tsx
@@ -1,5 +1,5 @@
 import { expect } from '@storybook/jest';
-import { Meta, StoryFn } from '@storybook/react';
+import { Meta } from '@storybook/react';
 import { userEvent, waitFor, within } from '@storybook/testing-library';
 import GifPicker, { Theme } from '..';
 
@@ -14,7 +14,7 @@ export default {
 			action: 'GIF selected'
 		},
 		theme: {
-			options: [ 'dark', 'light', 'auto' ],
+			options: ['dark', 'light', 'auto'],
 			control: {
 				type: 'radio'
 			}
@@ -35,6 +35,9 @@ export default {
 			type: { name: 'string' }
 		},
 		categoryHeight: {
+			type: { name: 'string' }
+		},
+		initialSearchTerm: {
 			type: { name: 'string' }
 		}
 	}
@@ -60,6 +63,14 @@ export const Search = {
 		const canvas = within(canvasElement);
 
 		await userEvent.type(canvas.getByTestId('gpr-search-input'), 'patrick bateman');
+	}
+};
+
+export const InitialSearch = {
+	...Home,
+	args: {
+		...Home.args,
+		initialSearchTerm: 'github',
 	}
 };
 


### PR DESCRIPTION
Based on discussion on this other PR https://github.com/MrBartusek/gif-picker-react/pull/32 I decided to send a suggestion to have a better UX + fixing some typos.

Behavior:
- Placeholder will still show `Search Tenor`.
- Initial search term will be the default and initial search to already show relevant/context gifs to the user.
- Categories won't show up because of the `initialSearchTerm`, added this note to the README docs.

![image](https://github.com/user-attachments/assets/d89185cc-dac3-46b7-8258-3044d9a5b5bd)
