### PR TITLE
Better support for custom providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Besides the built-in providers, you can write or import a custom one. A provider
 own backend, or a wrapper around an existing client. For real-world examples, see the built-in providers in the [`providers/` folder](https://github.com/MrBartusek/gif-picker-react/tree/master/src/providers).
 
 Providers should implement the [`GifProvider` interface][gif-provider-interface]. When using TypeScript you can use `implements GifProvider`, but it is not required; any class or object that
-satisfies this interface can be used as a provider. The return shapes ([`Gif`](#gif), [`GifPreview`](#gifpreview), `GifCategory`) are the same provider-agnostic objects documented above.
+satisfies this interface can be used as a provider. The return shapes (`Gif`, `GifPreview`, `GifCategory`) are the same provider-agnostic objects documented above.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![npm bundle size](https://img.shields.io/bundlephobia/min/gif-picker-react)](https://bundlephobia.com/package/gif-picker-react)
 [![downloads](https://img.shields.io/npm/dw/gif-picker-react)][npm]
 
-[npm]: https://www.npmjs.com/package/gif-picker-react
-
 ![demo](./demo.gif)
 
 A GIF picker component for React applications that supports [Tenor](https://tenor.com/), [Giphy](https://giphy.com/) and [Klipy](https://klipy.com/) and custom providers. This picker fits styling of [emoji-picker-react](https://www.npmjs.com/package/emoji-picker-react) and can be used next to it.
@@ -25,7 +23,7 @@ npm install gif-picker-react
 ## Usage
 
 ```tsx
-import GifPicker from 'gif-picker-react';
+import { GifPicker } from 'gif-picker-react';
 import { Tenor } from 'gif-picker-react/providers/tenor';
 
 function App() {
@@ -94,7 +92,7 @@ This is an example `Gif` object:
 
 ## GIF Providers
 
-The `provider` prop accepts any instance of the `GifProvider` abstract class. You can pick one of the built-in providers or create your own:
+The `provider` prop accepts any object that implements the `GifProvider` interface. You can pick one of the built-in providers or create your own:
 
 - [Tenor](#tenor)
 - [Custom Providers](#custom-providers)
@@ -105,7 +103,7 @@ The `provider` prop accepts any instance of the `GifProvider` abstract class. Yo
 > **Google is [shutting down the Tenor API](https://support.google.com/tenor/answer/10455265)**: new keys can't be generated since **January 13, 2026** and the API stops working on **June 30, 2026**. Multi-provider support (Giphy, Klipy and custom providers) ships in **v2.0.0** ([currently in development](https://github.com/MrBartusek/gif-picker-react/milestone/1)).
 
 ```tsx
-import GifPicker from 'gif-picker-react';
+import { GifPicker } from 'gif-picker-react';
 import { Tenor } from 'gif-picker-react/providers/tenor';
 
 <GifPicker provider={Tenor("YOUR_API_KEY")} />
@@ -138,9 +136,64 @@ The `Tenor` function optionally accepts a configuration object with the followin
 
 ### Custom Providers
 
-> This section should be improved - [#50](https://github.com/MrBartusek/gif-picker-react/issues/50)
+Besides the built-in providers, you can write or import a custom one. A provider just needs to implement the [`GifProvider` interface][gif-provider-interface]. The picker calls its methods to fetch GIFs. You can connect any GIF source: an unsupported third-party API, your
+own backend, or a wrapper around an existing client. For real-world examples, see the built-in providers in the [`providers/` folder](https://github.com/MrBartusek/gif-picker-react/tree/master/src/providers).
 
-You can connect any GIF source by extending the `GifProvider` abstract class and passing an instance to the `provider` prop.
+Providers should implement the [`GifProvider` interface][gif-provider-interface]. When using TypeScript you can use `implements GifProvider`, but it is not required; any class or object that
+satisfies this interface can be used as a provider. The return shapes ([`Gif`](#gif), [`GifPreview`](#gifpreview), `GifCategory`) are the same provider-agnostic objects documented above.
+
+#### Example
+
+The recommended approach is a factory function that returns the provider object:
+
+```tsx
+import { GifProvider, Gif } from 'gif-picker-react';
+
+export function Example(apiKey: string): GifProvider {
+  return new ExampleProvider(apiKey);
+}
+
+class ExampleProvider implements GifProvider {
+  constructor(private apiKey: string) {}
+
+  async getTrending() {
+    const data = await fetch(`https://api.example.com/trending?key=${this.apiKey}`)
+      .then((res) => res.json());
+    return data.items.map((item: any) => this.toGif(item));
+  }
+
+  async search(term: string) {
+    const data = await fetch(`https://api.example.com/search?q=${term}&key=${this.apiKey}`)
+      .then((res) => res.json());
+    return data.items.map((item: any) => this.toGif(item));
+  }
+
+  async getCategories() {
+    const data = await fetch(`https://api.example.com/categories?key=${this.apiKey}`)
+      .then((res) => res.json());
+    return data.items.map((category: any) => ({ name: category.name, imageUrl: category.image }));
+  }
+
+  private toGif(item: any) {
+    return {
+      id: item.id,
+      imageUrl: item.url,
+      width: item.width,
+      height: item.height,
+      description: item.title,
+      preview: { imageUrl: item.thumb, width: item.thumbWidth, height: item.thumbHeight },
+    };
+  }
+}
+```
+
+Then pass it to the picker:
+
+```tsx
+import { GifPicker } from 'gif-picker-react';
+
+<GifPicker provider={Example('YOUR_API_KEY')} />
+```
 
 ## Customization
 
@@ -173,3 +226,6 @@ You can find full list of all variables in [GifPickerReact.css](https://github.c
 Want to contribute to the project?
 
 First of all, thanks! Check [`CONTRIBUTING.md`](CONTRIBUTING.md) for more details.
+
+[npm]: https://www.npmjs.com/package/gif-picker-react
+[gif-provider-interface]: https://github.com/MrBartusek/gif-picker-react/blob/master/src/types/GifProvider.ts

--- a/src/GifPickerReact.tsx
+++ b/src/GifPickerReact.tsx
@@ -8,7 +8,8 @@ import ProviderContext from './context/ProviderContext';
 import './GifPickerReact.css';
 import usePickerContext from './hooks/usePickerContext';
 import useSettings from './hooks/useSettings';
-import { Gif, GifProvider } from './types/GifProvider';
+import { GifProvider } from './types/GifProvider';
+import { Gif } from './types/types';
 
 export enum Theme {
 	LIGHT = 'light',

--- a/src/components/body/Body.tsx
+++ b/src/components/body/Body.tsx
@@ -5,7 +5,7 @@ import './Body.css';
 import CategoryList from './CategoryList';
 import SearchResult from './SearchResult';
 import TrendingResult from './TrendingResult';
-import { Gif, GifCategory } from '../../types/GifProvider';
+import { Gif, GifCategory } from '../../types/types';
 
 const MAX_COLUMN_WIDTH = 170;
 

--- a/src/components/body/CategoryList.tsx
+++ b/src/components/body/CategoryList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Gif, GifCategory } from '../../types/GifProvider';
+import { Gif, GifCategory } from '../../types/types';
 import CategoryPlaceholder from '../placeholders/CategoryPlaceholder';
 import './CategoryList.css';
 import FeaturedCategory from './FeaturedCategory';

--- a/src/components/body/GifList.tsx
+++ b/src/components/body/GifList.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import './GifList.css';
 import GifListPlaceholder from './GifListPlaceholder';
 import ResultImage from './ResultImage';
-import { Gif } from '../../types/GifProvider';
+import { Gif } from '../../types/types';
 
 export interface GifListProps {
 	isLoading: boolean;

--- a/src/components/body/ResultImage.tsx
+++ b/src/components/body/ResultImage.tsx
@@ -21,7 +21,7 @@ function ResultImage({ gif, searchTerm }: ResultImageProps): React.JSX.Element {
 				await func(gif);
 			}
 
-			await provider.registerShare(gif, { searchTerm });
+			await provider.registerShare?.(gif, { searchTerm });
 		} catch (error) {
 			console.error('[gif-picker-react] Failed to handle GIF selection', error);
 		}

--- a/src/components/body/ResultImage.tsx
+++ b/src/components/body/ResultImage.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import SettingsContext from '../../context/SettingsContext';
 import ProviderContext from '../../context/ProviderContext';
 import './ResultImage.css';
-import { Gif } from '../../types/GifProvider';
+import { Gif } from '../../types/types';
 
 export interface ResultImageProps {
 	gif: Gif;

--- a/src/components/body/SearchResult.tsx
+++ b/src/components/body/SearchResult.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import ProviderContext from '../../context/ProviderContext';
 import GifList from './GifList';
-import { Gif } from '../../types/GifProvider';
+import { Gif } from '../../types/types';
 
 export interface SearchResultProps {
 	searchTerm: string;

--- a/src/components/body/TrendingResult.tsx
+++ b/src/components/body/TrendingResult.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import ProviderContext from '../../context/ProviderContext';
 import GifList from './GifList';
-import { Gif } from '../../types/GifProvider';
+import { Gif } from '../../types/types';
 
 export interface TrendingResultProps {
 	columnsCount: number;

--- a/src/components/header/Search.tsx
+++ b/src/components/header/Search.tsx
@@ -3,13 +3,12 @@ import PickerContext from '../../context/PickerContext';
 import SettingsContext from '../../context/SettingsContext';
 import ClearButton from './ClearButton';
 import './Search.css';
-import ProviderContext from '../../context/ProviderContext';
+import useAttribution from '../../hooks/useAttribution';
 
 function Search(): React.JSX.Element {
 	const [pickerContext, setPickerContext] = useContext(PickerContext);
 	const settings = useContext(SettingsContext);
-	const provider = useContext(ProviderContext);
-	const attribution = provider.getAttribution();
+	const attribution = useAttribution();
 
 	function onChange(event: React.ChangeEvent<HTMLInputElement>): void {
 		const contextCopy = Object.assign({}, pickerContext);

--- a/src/hooks/useAttribution.ts
+++ b/src/hooks/useAttribution.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+import ProviderContext from '../context/ProviderContext';
+import { GifProviderAttribution } from '../types/GifProvider';
+
+const DEFAULT_ATTRIBUTION: GifProviderAttribution = {
+	searchPlaceholder: 'Search GIFs',
+};
+
+function useAttribution(): GifProviderAttribution {
+	const provider = useContext(ProviderContext);
+	const attribution = provider.getAttribution?.();
+
+	return { ...DEFAULT_ATTRIBUTION, ...attribution };
+}
+
+export default useAttribution;

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,5 +1,6 @@
 import { GifPickerReactProps, Theme } from '../GifPickerReact';
-import { Gif, GifProvider } from '../types/GifProvider';
+import { GifProvider } from '../types/GifProvider';
+import { Gif } from '../types/types';
 
 /**
  * This is a parsed version of props with filled defaults

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,9 @@ import ErrorBoundary from './components/ErrorBoundary';
 import GifPickerReact, { GifPickerReactProps } from './GifPickerReact';
 
 export { Theme } from './GifPickerReact';
-export type { Gif } from './types/GifProvider';
+export { GifProvider } from './types/GifProvider';
+export type { GifProviderAttribution, RegisterShareContext } from './types/GifProvider';
+export type { Gif, GifCategory, GifPreview } from './types/types';
 
 export interface GifPickerProps extends GifPickerReactProps {}
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,11 @@ import ErrorBoundary from './components/ErrorBoundary';
 import GifPickerReact, { GifPickerReactProps } from './GifPickerReact';
 
 export { Theme } from './GifPickerReact';
-export { GifProvider } from './types/GifProvider';
-export type { GifProviderAttribution, RegisterShareContext } from './types/GifProvider';
+export type {
+	GifProvider,
+	GifProviderAttribution,
+	RegisterShareContext,
+} from './types/GifProvider';
 export type { Gif, GifCategory, GifPreview } from './types/types';
 
 export interface GifPickerProps extends GifPickerReactProps {}

--- a/src/providers/tenor/TenorProvider.ts
+++ b/src/providers/tenor/TenorProvider.ts
@@ -1,11 +1,6 @@
 import { ContentFilter } from './tenor.types';
-import {
-	Gif,
-	GifProviderAttribution,
-	GifCategory,
-	GifProvider,
-	RegisterShareContext,
-} from '../../types/GifProvider';
+import { GifProvider, GifProviderAttribution, RegisterShareContext } from '../../types/GifProvider';
+import { Gif, GifCategory } from '../../types/types';
 import { TenorCategoriesResponse, TenorResult, TenorSearchResponse } from './tenor.types';
 
 const MEDIA_FILTER = 'gif,tinygif';

--- a/src/providers/tenor/TenorProvider.ts
+++ b/src/providers/tenor/TenorProvider.ts
@@ -20,13 +20,11 @@ export function Tenor(apiKey: string, config?: TenorProviderConfig): GifProvider
 	return new TenorProvider(apiKey, config);
 }
 
-class TenorProvider extends GifProvider {
+class TenorProvider implements GifProvider {
 	constructor(
 		private apiKey: string,
 		private config: TenorProviderConfig = {},
-	) {
-		super();
-	}
+	) {}
 
 	public async getCategories(): Promise<GifCategory[]> {
 		const data = await this.fetchApi<TenorCategoriesResponse>('categories', { type: 'featured' });

--- a/src/types/GifProvider.ts
+++ b/src/types/GifProvider.ts
@@ -1,32 +1,4 @@
-type Awaitable<T> = T | PromiseLike<T>;
-
-export type GifCategory = {
-	imageUrl: string;
-	name: string;
-};
-
-export type GifPreview = {
-	imageUrl: string;
-	height: number;
-	width: number;
-};
-
-export type Gif = {
-	id: string;
-	imageUrl: string;
-	height: number;
-	width: number;
-	description?: string;
-	preview?: GifPreview;
-};
-
-export type RegisterShareContext = {
-	searchTerm?: string;
-};
-
-export type GifProviderAttribution = {
-	searchPlaceholder: string;
-};
+import { Awaitable, Gif, GifCategory } from './types';
 
 export abstract class GifProvider {
 	abstract getTrending(): Awaitable<Gif[]>;
@@ -41,3 +13,11 @@ export abstract class GifProvider {
 		return { searchPlaceholder: 'Search GIFs' };
 	}
 }
+
+export type RegisterShareContext = {
+	searchTerm?: string;
+};
+
+export type GifProviderAttribution = {
+	searchPlaceholder: string;
+};

--- a/src/types/GifProvider.ts
+++ b/src/types/GifProvider.ts
@@ -1,17 +1,32 @@
 import { Awaitable, Gif, GifCategory } from './types';
 
-export abstract class GifProvider {
-	abstract getTrending(): Awaitable<Gif[]>;
-	abstract getCategories(): Awaitable<GifCategory[]>;
-	abstract search(term: string): Awaitable<Gif[]>;
+export interface GifProvider {
+	/**
+	 * Fetches list of currently featured, trending or home page GIFs
+	 */
+	getTrending(): Awaitable<Gif[]>;
 
-	registerShare(_gif: Gif, _context: RegisterShareContext): Awaitable<void> {
-		return;
-	}
+	/**
+	 * Fetches most popular GIFs categories with their cover images
+	 */
+	getCategories(): Awaitable<GifCategory[]>;
 
-	getAttribution(): GifProviderAttribution {
-		return { searchPlaceholder: 'Search GIFs' };
-	}
+	/**
+	 * Searches GIFs by user-provided search term
+	 */
+	search(term: string): Awaitable<Gif[]>;
+
+	/**
+	 * If provider supports it, invoked after gif is clicked. This may
+	 * be required by provider for analytics.
+	 */
+	registerShare?(gif: Gif, context: RegisterShareContext): Awaitable<void>;
+
+	/**
+	 * Provides configuration of required attribution rules for
+	 * specific provider.
+	 */
+	getAttribution?(): Partial<GifProviderAttribution>;
 }
 
 export type RegisterShareContext = {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,21 @@
+export type Awaitable<T> = T | PromiseLike<T>;
+
+export type GifCategory = {
+	imageUrl: string;
+	name: string;
+};
+
+export type GifPreview = {
+	imageUrl: string;
+	height: number;
+	width: number;
+};
+
+export type Gif = {
+	id: string;
+	imageUrl: string;
+	height: number;
+	width: number;
+	description?: string;
+	preview?: GifPreview;
+};


### PR DESCRIPTION
Fixes: #50

This PR changes the `GifProvider` from an `abstract class` to an `interface` for easier implementation. Libiary now export all of the types needed for the creation of custom providers. I've also made better docs with example how to implement such provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated usage examples with new import style and expanded provider implementation guidance.

* **Bug Fixes**
  * Improved handling of optional provider methods through optional chaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->