### PR TITLE
Add provider for klipy.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ The `Klipy` function optionally accepts a configuration object with the followin
 | baseUrl | `string` | `https://api.klipy.com/api/v1/` | Base URL used for Klipy API requests. |
 | customerId | `string` | | A stable, unique identifier for the current user in your system (e.g. a hash or UUID). Used by Klipy for per-user personalization and anonymous share analytics. |
 | locale | `string` | | Country code / language of the user as a two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) code (e.g. `us`), optionally in `xx_YY` form (e.g. `en_US`). |
-| contentFilter | `ContentFilter` | `ContentFilter.OFF` | Controls the Klipy content safety filter level. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
+| contentFilter | `ContentFilter` | Klipy server default | Controls the Klipy content safety filter level. When unset, no filter is sent and the Klipy server default applies. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
+| quality | `KlipyQuality` | `KlipyQuality.MD` | Which size tier is used as the full-resolution image (the one passed to `onGifClick`). The grid preview always uses the small (`sm`) tier. If you are using Typescript you can use the `KlipyQuality` enum. Possible values are `hd`, `md`, `sm` and `xs`. |
 
 ### Custom Providers
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The `Tenor` function optionally accepts a configuration object with the followin
 | clientKey | `string` | `gif-picker-react` | Name of your application. Used to differentiate multiple applications using the same API key. |
 | country | `string` | `US` | Specify the country of origin for the request, as a two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code. |
 | locale | `string (xx_YY)` | `en_US` | Specify the default language to interpret the search string. xx is the language's [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code, while the optional _YY value is the two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code. |
-| contentFilter | `ContentFilter` | `ContentFilter.OFF` | Controls the Tenor [content filtering](https://developers.google.com/tenor/guides/content-filtering) options. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
+| contentFilter | `ContentFilter` | | Controls the Tenor [content filtering](https://developers.google.com/tenor/guides/content-filtering) options. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
 
 ### Klipy
 
@@ -172,8 +172,8 @@ The `Klipy` function optionally accepts a configuration object with the followin
 | baseUrl | `string` | `https://api.klipy.com/api/v1/` | Base URL used for Klipy API requests. |
 | customerId | `string` | | A stable, unique identifier for the current user in your system (e.g. a hash or UUID). Used by Klipy for per-user personalization and anonymous share analytics. |
 | locale | `string` | | Country code / language of the user as a two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) code (e.g. `us`), optionally in `xx_YY` form (e.g. `en_US`). |
-| contentFilter | `ContentFilter` | Klipy server default | Controls the Klipy content safety filter level. When unset, no filter is sent and the Klipy server default applies. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
-| quality | `KlipyQuality` | `KlipyQuality.MD` | Which size tier is used as the full-resolution image (the one passed to `onGifClick`). The grid preview always uses the small (`sm`) tier. If you are using Typescript you can use the `KlipyQuality` enum. Possible values are `hd`, `md`, `sm` and `xs`. |
+| contentFilter | `ContentFilter` | | Controls the Klipy content safety filter level. When unset, no filter is sent and the Klipy server default applies. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
+| quality | `KlipyQuality` | `KlipyQuality.MD` | Which size tier is passed to `onGifClick`. The grid preview always uses the small (`sm`) tier. If you are using Typescript you can use the `KlipyQuality` enum. Possible values are `hd`, `md`, `sm` and `xs`. |
 
 ### Custom Providers
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ The `Tenor` function optionally accepts a configuration object with the followin
 
 [Klipy](https://klipy.com/) is a GIF, sticker and clip provider.
 
+> [!NOTE]
+> Klipy ads are not supported by the picker. Ad objects returned by the Klipy API are filtered out, so make sure ads are disabled for your app key in the Klipy Partner Panel.
+
+
 ```tsx
 import { GifPicker } from 'gif-picker-react';
 import { Klipy } from 'gif-picker-react/providers/klipy';

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The `provider` prop accepts any object that implements the `GifProvider` interfa
 
 ### Tenor
 
-[Tenor](https://tenor.com/) is a GIF provider by Google.
+**[Tenor](https://tenor.com/)** is a GIF provider by Google.
 
 > [!WARNING]
 > **Google is [shutting down the Tenor API](https://support.google.com/tenor/answer/10455265)**: new keys can't be generated since **January 13, 2026** and the API stops working on **June 30, 2026**. Multi-provider support (Giphy, Klipy and custom providers) ships in **v2.0.0** ([currently in development](https://github.com/MrBartusek/gif-picker-react/milestone/1)).
@@ -139,7 +139,7 @@ The `Tenor` function optionally accepts a configuration object with the followin
 
 ### Klipy
 
-[Klipy](https://klipy.com/) is a GIF, sticker and clip provider.
+**[Klipy](https://klipy.com/)** is a GIF, sticker and clip provider built as a drop-in Tenor replacement, so it can be used to migrate off the Tenor API as it shuts down.
 
 > [!NOTE]
 > Klipy ads are not supported by the picker. Ad objects returned by the Klipy API are filtered out, so make sure ads are disabled for your app key in the Klipy Partner Panel.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ The `Klipy` function optionally accepts a configuration object with the followin
 | customerId | `string` | | A stable, unique identifier for the current user in your system (e.g. a hash or UUID). Used by Klipy for per-user personalization and anonymous share analytics. |
 | locale | `string` | | Country code / language of the user as a two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) code (e.g. `us`), optionally in `xx_YY` form (e.g. `en_US`). |
 | contentFilter | `ContentFilter` | | Controls the Klipy content safety filter level. When unset, no filter is sent and the Klipy server default applies. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
-| quality | `KlipyQuality` | `KlipyQuality.MD` | Which size tier is passed to `onGifClick`. The grid preview always uses the small (`sm`) tier. If you are using Typescript you can use the `KlipyQuality` enum. Possible values are `hd`, `md`, `sm` and `xs`. |
+| quality | `KlipyQuality` | `KlipyQuality.MD` | Which size tier is passed to `onGifClick`. If you are using Typescript you can use the `KlipyQuality` enum. Possible values are `hd`, `md`, `sm` and `xs`. |
+| previewQuality | `KlipyQuality` | `KlipyQuality.SM` | Which size tier is used for the preview gifs rendered in the picker grid. If you are using Typescript you can use the `KlipyQuality` enum. Possible values are `hd`, `md`, `sm` and `xs`. |
 
 ### Custom Providers
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,12 @@ This is an example `Gif` object:
 The `provider` prop accepts any object that implements the `GifProvider` interface. You can pick one of the built-in providers or create your own:
 
 - [Tenor](#tenor)
+- [Klipy](#klipy)
 - [Custom Providers](#custom-providers)
 
 ### Tenor
+
+[Tenor](https://tenor.com/) is a GIF provider by Google.
 
 > [!WARNING]
 > **Google is [shutting down the Tenor API](https://support.google.com/tenor/answer/10455265)**: new keys can't be generated since **January 13, 2026** and the API stops working on **June 30, 2026**. Multi-provider support (Giphy, Klipy and custom providers) ships in **v2.0.0** ([currently in development](https://github.com/MrBartusek/gif-picker-react/milestone/1)).
@@ -133,6 +136,39 @@ The `Tenor` function optionally accepts a configuration object with the followin
 | country | `string` | `US` | Specify the country of origin for the request, as a two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code. |
 | locale | `string (xx_YY)` | `en_US` | Specify the default language to interpret the search string. xx is the language's [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code, while the optional _YY value is the two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) country code. |
 | contentFilter | `ContentFilter` | `ContentFilter.OFF` | Controls the Tenor [content filtering](https://developers.google.com/tenor/guides/content-filtering) options. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
+
+### Klipy
+
+[Klipy](https://klipy.com/) is a GIF, sticker and clip provider.
+
+```tsx
+import { GifPicker } from 'gif-picker-react';
+import { Klipy } from 'gif-picker-react/providers/klipy';
+
+<GifPicker provider={Klipy("YOUR_APP_KEY")} />
+```
+
+#### Obtaining a Klipy app key
+
+In order to use the `GifPicker` element with the `Klipy` provider you are required to
+provide a Klipy app key. To obtain this key please follow this simple guide:
+
+1. Sign up at the [Klipy Partner Panel](https://partner.klipy.com)
+1. Navigate to the *API Keys* page
+1. Select *Add Platform* and create your platform to generate an app key
+1. Copy the generated app key
+1. Pass this key to the `Klipy` provider, e.g. `Klipy("YOUR_APP_KEY")`
+
+#### Configuration
+
+The `Klipy` function optionally accepts a configuration object with the following options:
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| baseUrl | `string` | `https://api.klipy.com/api/v1/` | Base URL used for Klipy API requests. |
+| customerId | `string` | | A stable, unique identifier for the current user in your system (e.g. a hash or UUID). Used by Klipy for per-user personalization and anonymous share analytics. |
+| locale | `string` | | Country code / language of the user as a two-letter [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) code (e.g. `us`), optionally in `xx_YY` form (e.g. `en_US`). |
+| contentFilter | `ContentFilter` | `ContentFilter.OFF` | Controls the Klipy content safety filter level. If you are using Typescript you can use the `ContentFilter` enum. Possible values are `high`, `medium`, `low` and `off`. |
 
 ### Custom Providers
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ The `Tenor` function optionally accepts a configuration object with the followin
 > [!NOTE]
 > Klipy ads are not supported by the picker. Ad objects returned by the Klipy API are filtered out, so make sure ads are disabled for your app key in the Klipy Partner Panel.
 
-
 ```tsx
 import { GifPicker } from 'gif-picker-react';
 import { Klipy } from 'gif-picker-react/providers/klipy';

--- a/src/components/body/CategoryList.tsx
+++ b/src/components/body/CategoryList.tsx
@@ -44,6 +44,7 @@ function CategoryList({
 							key={i}
 							image={cat.imageUrl}
 							name={cat.name}
+							searchTerm={cat.searchTerm ?? cat.name}
 						/>
 					))}
 				</>

--- a/src/components/body/FeaturedCategory.tsx
+++ b/src/components/body/FeaturedCategory.tsx
@@ -5,14 +5,15 @@ import Category from './Category';
 export interface FeaturedCategory {
 	image: string;
 	name: string;
+	searchTerm: string;
 }
 
-function FeaturedCategory({ image, name }: FeaturedCategory): React.JSX.Element {
+function FeaturedCategory({ image, name, searchTerm }: FeaturedCategory): React.JSX.Element {
 	const [pickerContext, setPickerContext] = useContext(PickerContext);
 
 	function onClick(): void {
 		const contextCopy = Object.assign({}, pickerContext);
-		contextCopy.searchTerm = name;
+		contextCopy.searchTerm = searchTerm;
 		setPickerContext(contextCopy);
 	}
 

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -5,6 +5,7 @@ import {
 	KlipyCategoriesData,
 	KlipyEnvelope,
 	KlipyItem,
+	KlipyItemType,
 	KlipyListData,
 	KlipyQuality,
 } from './klipy.types';
@@ -131,7 +132,7 @@ class KlipyProvider implements GifProvider {
 	}
 
 	private parseGif(item: KlipyItem): Gif | null {
-		if (item.type !== 'gif') {
+		if (item.type !== KlipyItemType.GIF) {
 			return null;
 		}
 

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -6,17 +6,21 @@ import {
 	KlipyEnvelope,
 	KlipyItem,
 	KlipyListData,
+	KlipyQuality,
 } from './klipy.types';
 
 const BASE_URL = 'https://api.klipy.com/api/v1/';
 const FORMAT_FILTER = 'gif';
 const KLIPY_MAX_PER_PAGE = 50;
+const PREVIEW_SIZE = KlipyQuality.SM;
+const DEFAULT_QUALITY = KlipyQuality.MD;
 
 export type KlipyProviderConfig = {
 	baseUrl?: string;
 	customerId?: string;
 	locale?: string;
 	contentFilter?: ContentFilter;
+	quality?: KlipyQuality;
 };
 
 export function Klipy(appKey: string, config?: KlipyProviderConfig): GifProvider {
@@ -30,10 +34,16 @@ class KlipyProvider implements GifProvider {
 	) {}
 
 	public async getCategories(): Promise<GifCategory[]> {
-		const data = await this.fetchApi<KlipyCategoriesData>('categories');
+		const params: Record<string, string> = {};
+		if (this.config.locale) {
+			params.locale = this.config.locale;
+		}
+
+		const data = await this.fetchApi<KlipyCategoriesData>('categories', params);
 
 		return data.categories.map((category) => ({
-			name: category.query,
+			name: category.category,
+			searchTerm: category.query,
 			imageUrl: category.preview_url,
 		}));
 	}
@@ -44,9 +54,10 @@ class KlipyProvider implements GifProvider {
 			page: 1,
 			per_page: KLIPY_MAX_PER_PAGE,
 			format_filter: FORMAT_FILTER,
+			...this.commonParams(),
 		});
 
-		return data.data.map((item) => this.parseGif(item));
+		return this.parseGifs(data.data);
 	}
 
 	public async getTrending(): Promise<Gif[]> {
@@ -54,9 +65,10 @@ class KlipyProvider implements GifProvider {
 			page: 1,
 			per_page: KLIPY_MAX_PER_PAGE,
 			format_filter: FORMAT_FILTER,
+			...this.commonParams(),
 		});
 
-		return data.data.map((item) => this.parseGif(item));
+		return this.parseGifs(data.data);
 	}
 
 	public async registerShare(gif: Gif, context: RegisterShareContext): Promise<void> {
@@ -72,6 +84,24 @@ class KlipyProvider implements GifProvider {
 		});
 	}
 
+	public getAttribution(): GifProviderAttribution {
+		return { searchPlaceholder: 'Search KLIPY' };
+	}
+
+	private commonParams(): Record<string, string> {
+		const params: Record<string, string> = {};
+		if (this.config.locale) {
+			params.locale = this.config.locale;
+		}
+		if (this.config.contentFilter) {
+			params.content_filter = this.config.contentFilter;
+		}
+		if (this.config.customerId) {
+			params.customer_id = this.config.customerId;
+		}
+		return params;
+	}
+
 	private async fetchApi<T = any>(
 		endpoint: string,
 		params?: Record<string, any>,
@@ -79,16 +109,6 @@ class KlipyProvider implements GifProvider {
 	): Promise<T> {
 		const baseUrl = this.config.baseUrl ?? BASE_URL;
 		const url = new URL(`${baseUrl}${this.appKey}/gifs/${endpoint}`);
-
-		if (this.config.locale) {
-			url.searchParams.set('locale', this.config.locale);
-		}
-		if (this.config.contentFilter) {
-			url.searchParams.set('content_filter', this.config.contentFilter);
-		}
-		if (this.config.customerId) {
-			url.searchParams.set('customer_id', this.config.customerId);
-		}
 
 		if (params) {
 			Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, String(v)));
@@ -98,22 +118,34 @@ class KlipyProvider implements GifProvider {
 		if (!res.ok) {
 			throw new Error(`Klipy API request failed (${res.status} ${res.statusText})`);
 		}
+
 		const body = (await res.json()) as KlipyEnvelope<T>;
+		if (!body.result) {
+			throw new Error('Klipy API request failed (result: false)');
+		}
 		return body.data;
 	}
 
-	public getAttribution(): GifProviderAttribution {
-		return { searchPlaceholder: 'Search KLIPY' };
+	private parseGifs(items: KlipyItem[]): Gif[] {
+		return items.map((item) => this.parseGif(item)).filter((gif): gif is Gif => gif !== null);
 	}
 
-	private parseGif(item: KlipyItem): Gif {
-		const gif = item.file.md.gif;
-		const preview = item.file.sm.gif;
+	private parseGif(item: KlipyItem): Gif | null {
+		if (item.type !== 'gif') {
+			return null;
+		}
+
+		const full = item.file?.[this.config.quality ?? DEFAULT_QUALITY]?.gif;
+		const preview = item.file?.[PREVIEW_SIZE]?.gif;
+		if (!full || !preview) {
+			return null;
+		}
+
 		return {
 			id: item.slug,
-			imageUrl: gif.url,
-			width: gif.width,
-			height: gif.height,
+			imageUrl: full.url,
+			width: full.width,
+			height: full.height,
 			description: item.title,
 			preview: {
 				imageUrl: preview.url,

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -13,8 +13,8 @@ import {
 const BASE_URL = 'https://api.klipy.com/api/v1/';
 const FORMAT_FILTER = 'gif';
 const KLIPY_MAX_PER_PAGE = 50;
-const PREVIEW_SIZE = KlipyQuality.SM;
 const DEFAULT_QUALITY = KlipyQuality.MD;
+const DEFAULT_PREVIEW_QUALITY = KlipyQuality.SM;
 
 export type KlipyProviderConfig = {
 	baseUrl?: string;
@@ -22,6 +22,7 @@ export type KlipyProviderConfig = {
 	locale?: string;
 	contentFilter?: ContentFilter;
 	quality?: KlipyQuality;
+	previewQuality?: KlipyQuality;
 };
 
 export function Klipy(appKey: string, config?: KlipyProviderConfig): GifProvider {
@@ -120,10 +121,11 @@ class KlipyProvider implements GifProvider {
 			throw new Error(`Klipy API request failed (${res.status} ${res.statusText})`);
 		}
 
-		const body = (await res.json()) as KlipyEnvelope<T>;
+		const body: KlipyEnvelope<T> = await res.json();
 		if (!body.result) {
 			throw new Error('Klipy API request failed (result: false)');
 		}
+
 		return body.data;
 	}
 
@@ -136,8 +138,11 @@ class KlipyProvider implements GifProvider {
 			return null;
 		}
 
-		const full = item.file?.[this.config.quality ?? DEFAULT_QUALITY]?.gif;
-		const preview = item.file?.[PREVIEW_SIZE]?.gif;
+		const fullQuality = this.config.quality ?? DEFAULT_QUALITY;
+		const previewQuality = this.config.previewQuality ?? DEFAULT_PREVIEW_QUALITY;
+
+		const full = item.file?.[fullQuality]?.gif;
+		const preview = item.file?.[previewQuality]?.gif;
 		if (!full || !preview) {
 			return null;
 		}

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -145,8 +145,8 @@ class KlipyProvider implements GifProvider {
 		const fullQuality = this.config.quality ?? DEFAULT_QUALITY;
 		const previewQuality = this.config.previewQuality ?? DEFAULT_PREVIEW_QUALITY;
 
-		const full = item.file?.[fullQuality]?.gif;
-		const preview = item.file?.[previewQuality]?.gif;
+		const full = item.file[fullQuality].gif;
+		const preview = item.file[previewQuality].gif;
 		if (!full || !preview) {
 			return null;
 		}

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -1,0 +1,125 @@
+import { GifProvider, GifProviderAttribution, RegisterShareContext } from '../../types/GifProvider';
+import { Gif, GifCategory } from '../../types/types';
+import {
+	ContentFilter,
+	KlipyCategoriesData,
+	KlipyEnvelope,
+	KlipyItem,
+	KlipyListData,
+} from './klipy.types';
+
+const BASE_URL = 'https://api.klipy.com/api/v1/';
+const FORMAT_FILTER = 'gif';
+const KLIPY_MAX_PER_PAGE = 50;
+
+export type KlipyProviderConfig = {
+	baseUrl?: string;
+	customerId?: string;
+	locale?: string;
+	contentFilter?: ContentFilter;
+};
+
+export function Klipy(appKey: string, config?: KlipyProviderConfig): GifProvider {
+	return new KlipyProvider(appKey, config);
+}
+
+class KlipyProvider implements GifProvider {
+	constructor(
+		private appKey: string,
+		private config: KlipyProviderConfig = {},
+	) {}
+
+	public async getCategories(): Promise<GifCategory[]> {
+		const data = await this.fetchApi<KlipyCategoriesData>('categories');
+
+		return data.categories.map((category) => ({
+			name: category.query,
+			imageUrl: category.preview_url,
+		}));
+	}
+
+	public async search(term: string): Promise<Gif[]> {
+		const data = await this.fetchApi<KlipyListData>('search', {
+			q: term,
+			page: 1,
+			per_page: KLIPY_MAX_PER_PAGE,
+			format_filter: FORMAT_FILTER,
+		});
+
+		return data.data.map((item) => this.parseGif(item));
+	}
+
+	public async getTrending(): Promise<Gif[]> {
+		const data = await this.fetchApi<KlipyListData>('trending', {
+			page: 1,
+			per_page: KLIPY_MAX_PER_PAGE,
+			format_filter: FORMAT_FILTER,
+		});
+
+		return data.data.map((item) => this.parseGif(item));
+	}
+
+	public async registerShare(gif: Gif, context: RegisterShareContext): Promise<void> {
+		const body: Record<string, string> = { q: context.searchTerm ?? '' };
+		if (this.config.customerId) {
+			body.customer_id = this.config.customerId;
+		}
+
+		await this.fetchApi(`share/${gif.id}`, undefined, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body),
+		});
+	}
+
+	private async fetchApi<T = any>(
+		endpoint: string,
+		params?: Record<string, any>,
+		init?: RequestInit,
+	): Promise<T> {
+		const baseUrl = this.config.baseUrl ?? BASE_URL;
+		const url = new URL(`${baseUrl}${this.appKey}/gifs/${endpoint}`);
+
+		if (this.config.locale) {
+			url.searchParams.set('locale', this.config.locale);
+		}
+		if (this.config.contentFilter) {
+			url.searchParams.set('content_filter', this.config.contentFilter);
+		}
+		if (this.config.customerId) {
+			url.searchParams.set('customer_id', this.config.customerId);
+		}
+
+		if (params) {
+			Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, String(v)));
+		}
+
+		const res = await fetch(url.toString(), init);
+		if (!res.ok) {
+			throw new Error(`Klipy API request failed (${res.status} ${res.statusText})`);
+		}
+		const body = (await res.json()) as KlipyEnvelope<T>;
+		return body.data;
+	}
+
+	public getAttribution(): GifProviderAttribution {
+		return { searchPlaceholder: 'Search KLIPY' };
+	}
+
+	private parseGif(item: KlipyItem): Gif {
+		const gif = item.file.md.gif;
+		const preview = item.file.sm.gif;
+		return {
+			id: item.slug,
+			imageUrl: gif.url,
+			width: gif.width,
+			height: gif.height,
+			description: item.title,
+			preview: {
+				imageUrl: preview.url,
+				width: preview.width,
+				height: preview.height,
+			},
+		};
+	}
+}

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -30,10 +30,14 @@ export function Klipy(appKey: string, config?: KlipyProviderConfig): GifProvider
 }
 
 class KlipyProvider implements GifProvider {
+	private readonly baseUrl: string;
+
 	constructor(
 		private appKey: string,
 		private config: KlipyProviderConfig = {},
-	) {}
+	) {
+		this.baseUrl = (config.baseUrl ?? BASE_URL).replace(/\/+$/, '') + '/';
+	}
 
 	public async getCategories(): Promise<GifCategory[]> {
 		const params: Record<string, string> = {};
@@ -113,8 +117,7 @@ class KlipyProvider implements GifProvider {
 		params?: Record<string, any>,
 		init?: RequestInit,
 	): Promise<T> {
-		const baseUrl = this.config.baseUrl ?? BASE_URL;
-		const url = new URL(`${baseUrl}${this.appKey}/gifs/${endpoint}`);
+		const url = new URL(`${this.appKey}/gifs/${endpoint}`, this.baseUrl);
 
 		if (params) {
 			Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, String(v)));

--- a/src/providers/klipy/KlipyProvider.ts
+++ b/src/providers/klipy/KlipyProvider.ts
@@ -56,7 +56,7 @@ class KlipyProvider implements GifProvider {
 			page: 1,
 			per_page: KLIPY_MAX_PER_PAGE,
 			format_filter: FORMAT_FILTER,
-			...this.commonParams(),
+			...this.buildParams(),
 		});
 
 		return this.parseGifs(data.data);
@@ -67,7 +67,7 @@ class KlipyProvider implements GifProvider {
 			page: 1,
 			per_page: KLIPY_MAX_PER_PAGE,
 			format_filter: FORMAT_FILTER,
-			...this.commonParams(),
+			...this.buildParams(),
 		});
 
 		return this.parseGifs(data.data);
@@ -90,17 +90,21 @@ class KlipyProvider implements GifProvider {
 		return { searchPlaceholder: 'Search KLIPY' };
 	}
 
-	private commonParams(): Record<string, string> {
+	private buildParams(): Record<string, string> {
 		const params: Record<string, string> = {};
+
 		if (this.config.locale) {
 			params.locale = this.config.locale;
 		}
+
 		if (this.config.contentFilter) {
 			params.content_filter = this.config.contentFilter;
 		}
+
 		if (this.config.customerId) {
 			params.customer_id = this.config.customerId;
 		}
+
 		return params;
 	}
 

--- a/src/providers/klipy/index.ts
+++ b/src/providers/klipy/index.ts
@@ -1,2 +1,2 @@
 export { Klipy, type KlipyProviderConfig } from './KlipyProvider';
-export { ContentFilter } from './klipy.types';
+export { ContentFilter, KlipyQuality } from './klipy.types';

--- a/src/providers/klipy/index.ts
+++ b/src/providers/klipy/index.ts
@@ -1,0 +1,2 @@
+export { Klipy, type KlipyProviderConfig } from './KlipyProvider';
+export { ContentFilter } from './klipy.types';

--- a/src/providers/klipy/klipy.types.ts
+++ b/src/providers/klipy/klipy.types.ts
@@ -5,6 +5,13 @@ export enum ContentFilter {
 	OFF = 'off',
 }
 
+export enum KlipyQuality {
+	HD = 'hd',
+	MD = 'md',
+	SM = 'sm',
+	XS = 'xs',
+}
+
 export interface KlipyMediaFormat {
 	url: string;
 	width: number;
@@ -13,7 +20,7 @@ export interface KlipyMediaFormat {
 }
 
 export interface KlipyFileVariant {
-	gif: KlipyMediaFormat;
+	gif?: KlipyMediaFormat;
 	webp?: KlipyMediaFormat;
 	jpg?: KlipyMediaFormat;
 	mp4?: KlipyMediaFormat;
@@ -24,12 +31,7 @@ export interface KlipyItem {
 	id: number;
 	slug: string;
 	title: string;
-	file: {
-		hd: KlipyFileVariant;
-		md: KlipyFileVariant;
-		sm: KlipyFileVariant;
-		xs: KlipyFileVariant;
-	};
+	file: Record<KlipyQuality, KlipyFileVariant>;
 	tags: string[];
 	type: string;
 	blur_preview?: string;

--- a/src/providers/klipy/klipy.types.ts
+++ b/src/providers/klipy/klipy.types.ts
@@ -5,6 +5,11 @@ export enum ContentFilter {
 	OFF = 'off',
 }
 
+export enum KlipyItemType {
+	GIF = 'gif',
+	AD = 'ad',
+}
+
 export enum KlipyQuality {
 	HD = 'hd',
 	MD = 'md',
@@ -33,7 +38,7 @@ export interface KlipyItem {
 	title: string;
 	file: Record<KlipyQuality, KlipyFileVariant>;
 	tags: string[];
-	type: string;
+	type: KlipyItemType;
 	blur_preview?: string;
 }
 

--- a/src/providers/klipy/klipy.types.ts
+++ b/src/providers/klipy/klipy.types.ts
@@ -1,0 +1,59 @@
+export enum ContentFilter {
+	HIGH = 'high',
+	MEDIUM = 'medium',
+	LOW = 'low',
+	OFF = 'off',
+}
+
+export interface KlipyMediaFormat {
+	url: string;
+	width: number;
+	height: number;
+	size: number;
+}
+
+export interface KlipyFileVariant {
+	gif: KlipyMediaFormat;
+	webp?: KlipyMediaFormat;
+	jpg?: KlipyMediaFormat;
+	mp4?: KlipyMediaFormat;
+	webm?: KlipyMediaFormat;
+}
+
+export interface KlipyItem {
+	id: number;
+	slug: string;
+	title: string;
+	file: {
+		hd: KlipyFileVariant;
+		md: KlipyFileVariant;
+		sm: KlipyFileVariant;
+		xs: KlipyFileVariant;
+	};
+	tags: string[];
+	type: string;
+	blur_preview?: string;
+}
+
+export interface KlipyEnvelope<T> {
+	result: boolean;
+	data: T;
+}
+
+export interface KlipyListData {
+	data: KlipyItem[];
+	current_page: number;
+	per_page: number;
+	has_next: boolean;
+}
+
+export interface KlipyCategory {
+	category: string;
+	query: string;
+	preview_url: string;
+}
+
+export interface KlipyCategoriesData {
+	locale: string;
+	categories: KlipyCategory[];
+}

--- a/src/providers/tenor/TenorProvider.ts
+++ b/src/providers/tenor/TenorProvider.ts
@@ -30,7 +30,8 @@ class TenorProvider implements GifProvider {
 		const data = await this.fetchApi<TenorCategoriesResponse>('categories', { type: 'featured' });
 
 		return data.tags.map((tag) => ({
-			name: tag.searchterm,
+			name: tag.name,
+			searchTerm: tag.searchterm,
 			imageUrl: tag.image,
 		}));
 	}

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -11,6 +11,7 @@ If you are seeing this, you have successfully started Storybook. This tool lets 
 | Provider | Token | Status |
 | --- | --- | --- |
 | Tenor | `STORYBOOK_TENOR_TOKEN` | {process.env.STORYBOOK_TENOR_TOKEN ? '✅' : '❌'} |
+| Klipy | `STORYBOOK_KLIPY_TOKEN` | {process.env.STORYBOOK_KLIPY_TOKEN ? '✅' : '❌'} |
 
 ## Future reading
 

--- a/src/stories/Klipy.stories.tsx
+++ b/src/stories/Klipy.stories.tsx
@@ -1,0 +1,26 @@
+import { ContentFilter, Klipy } from '../providers/klipy';
+import { createProviderMeta } from './providerStory';
+
+export default {
+	title: 'Providers/Klipy',
+	...createProviderMeta((args) => Klipy(process.env.STORYBOOK_KLIPY_TOKEN!, args), {
+		contentFilter: {
+			options: Object.values(ContentFilter),
+			control: { type: 'select' },
+			table: { category: 'Klipy' },
+		},
+		locale: {
+			control: { type: 'text' },
+			table: { category: 'Klipy' },
+		},
+		customerId: {
+			control: { type: 'text' },
+			table: { category: 'Klipy' },
+		},
+	}),
+	args: {
+		contentFilter: ContentFilter.OFF,
+	},
+};
+
+export { Home, DarkTheme, HomeCategory, Trending } from './providerStory';

--- a/src/stories/Klipy.stories.tsx
+++ b/src/stories/Klipy.stories.tsx
@@ -1,4 +1,4 @@
-import { ContentFilter, Klipy } from '../providers/klipy';
+import { ContentFilter, Klipy, KlipyQuality } from '../providers/klipy';
 import { createProviderMeta } from './providerStory';
 
 export default {
@@ -6,6 +6,16 @@ export default {
 	...createProviderMeta((args) => Klipy(import.meta.env.STORYBOOK_KLIPY_TOKEN!, args), {
 		contentFilter: {
 			options: Object.values(ContentFilter),
+			control: { type: 'select' },
+			table: { category: 'Klipy' },
+		},
+		quality: {
+			options: Object.values(KlipyQuality),
+			control: { type: 'select' },
+			table: { category: 'Klipy' },
+		},
+		previewQuality: {
+			options: Object.values(KlipyQuality),
 			control: { type: 'select' },
 			table: { category: 'Klipy' },
 		},
@@ -20,6 +30,8 @@ export default {
 	}),
 	args: {
 		contentFilter: ContentFilter.OFF,
+		quality: KlipyQuality.MD,
+		previewQuality: KlipyQuality.SM,
 	},
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,7 +2,11 @@ export type Awaitable<T> = T | PromiseLike<T>;
 
 export type GifCategory = {
 	imageUrl: string;
+
 	name: string;
+
+	/** Term searched when the category is clicked. Falls back to `name`. */
+	searchTerm?: string;
 };
 
 export type GifPreview = {


### PR DESCRIPTION
Fixes: #42

[Klipy](https://klipy.com) seems to be the most popular replacement for Tenor. They offer the easy migration API, which just changes the base URL, but it seems like a better idea to write an implementation with their regular API, rather than rely on this tenor shim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Klipy as a new GIF provider with configurable content filtering, quality settings, and locale support
  * Enhanced category navigation to support custom search terms for improved discoverability

* **Bug Fixes**
  * Corrected Tenor provider's category mapping to properly utilize search terms

* **Documentation**
  * Updated documentation with Klipy provider setup instructions and configuration options
  * Added interactive examples for the new Klipy provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->